### PR TITLE
Various pipeline fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ COPY ./poetry.lock ./pyproject.toml ./
 # Install python dependencies using poetry
 RUN poetry config virtualenvs.create false
 RUN poetry install
+RUN playwright install
+RUN playwright install-deps
 
 # Copy files to image
 COPY ./src ./src

--- a/cli/run_parser.py
+++ b/cli/run_parser.py
@@ -57,7 +57,7 @@ def main(input_dir: Path, output_dir: Path):
 
     logger.info("Running HTML parser")
 
-    for task in tqdm(tasks):
+    for task in tqdm(tasks, total=len(list(input_dir.glob("*.json")))):
         parsed_html = html_parser.parse(task).detect_language()
         output_path = output_dir / f"{task.id}.json"
 

--- a/src/combined.py
+++ b/src/combined.py
@@ -99,11 +99,17 @@ class CombinedParser(HTMLParser):
             logger.info(
                 f"Falling back to JS-enabled browser for {input.id} ({input.url})"
             )
-            with sync_playwright() as playwright:
-                html_playwright = self._get_html_with_js_enabled(playwright, input.url)
-                parsed_html_playwright = self.parse_html(html_playwright, input)
+            try:
+                with sync_playwright() as playwright:
+                    html_playwright = self._get_html_with_js_enabled(
+                        playwright, input.url
+                    )
+                    parsed_html_playwright = self.parse_html(html_playwright, input)
 
-            return parsed_html_playwright
+                return parsed_html_playwright
+            except Exception as e:
+                logger.error(f"Could not fetch {input.url} for {input.id}: {e}")
+                return self._get_empty_response(input)
 
         return parsed_html
 


### PR DESCRIPTION
Some quick fixes and enhancements that I found when running the whole prototype HTML corpus through the parser.

- install playwright dependencies in Docker
- add total count to CLI progress bar
- allow playwright failure without crashing whole process

See [DSCI-99](https://linear.app/climate-policy-radar/issue/DSCI-99/assess-how-widespread-ssl-handshake-error-is) for investigation into the legislation.gov.au bug. TLDR - it only affects this domain & I've raised [DSCI-101](https://linear.app/climate-policy-radar/issue/DSCI-101/resolve-ssl-handshake-error-on-legislationgovau) to deal with it with them directly.